### PR TITLE
Add a header to show traffic has come through the gov.uk router

### DIFF
--- a/router/src/main/scala/uk/gov/gds/router/util/HttpProxy.scala
+++ b/router/src/main/scala/uk/gov/gds/router/util/HttpProxy.scala
@@ -49,6 +49,7 @@ object HttpProxy extends Logging {
       }
     }
 
+    message.addHeader("X-GovUK-Router-Request", "true")
     requestInfo.headers.filter(h => h._1 == HTTP.TARGET_HOST).foreach(h =>  message.addHeader("X-Forwarded-Host", h._2))
 
     val targetResponse = httpClient.execute(message)

--- a/router/src/test/scala/uk/gov/gds/router/integration/RouterIntegrationTest.scala
+++ b/router/src/test/scala/uk/gov/gds/router/integration/RouterIntegrationTest.scala
@@ -231,6 +231,12 @@ class RouterIntegrationTest extends MongoDatabaseBackedTest with ShouldMatchers 
     responseWithCookiesFromServer.body.contains("test-cookie=this is a cookie") should be(true)
   }
 
+  test("Sets X-GovUK-Router-Request") {
+    val httpGet = new HttpGet(buildUrl("/route/test/incoming-headers"))
+    val response = Response(httpGet)
+    response.body.contains("X-GovUK-Router-Request=true") should be(true)
+  }
+
   test("Original host sent to backend as X_FORWARDED_HOST") {
     val httpGet = new HttpGet(buildUrl("/route/test/incoming-headers"))
     httpGet.addHeader("Host", "original.example.com:3100")


### PR DESCRIPTION
For whitehall, we'd like to identify all traffic that has come through the gov.uk router so we can block all access to any admin functionality to this traffic.  The cleanest way to do this seems to us to be to add a header.  For now we've called this header `X-GovUK-Router-Request` but we're open to suggestions as to what it really should be.
