### PR TITLE
Filter response headers in the router (not slimmer)

### DIFF
--- a/router-integration-tests/src/test/scala/uk/gov/gds/router/integration/RouterIntegrationTest.scala
+++ b/router-integration-tests/src/test/scala/uk/gov/gds/router/integration/RouterIntegrationTest.scala
@@ -58,13 +58,21 @@ class RouterIntegrationTest extends MongoDatabaseBackedTest with ShouldMatchers 
     response.status should be(201)
   }
 
-  test("Can get headers from response") {
-    val response = get("/route/test/set-header")
-    response.headers.contains(Header("X-Test", "test")) should be(true)
+  test("Can get standard headers from response") {
+    val response = get("/route/test/set-allowed-headers")
+    response.headers.contains(Header("Cache-Control", "cache-control-value")) should be(true)
+    response.headers.contains(Header("Content-Type", "content-type-value;charset=UTF-8")) should be(true)
+    response.headers.contains(Header("ETag", "etag-value")) should be(true)
+    response.headers.contains(Header("Expires", "expires-value")) should be(true)
+    response.headers.contains(Header("Last-Modified", "last-modified-value")) should be(true)
+    response.headers.contains(Header("Location", "location-value")) should be(true)
+    response.headers.contains(Header("Set-Cookie", "set-cookie-value")) should be(true)
+    response.headers.contains(Header("Vary", "vary-value")) should be(true)
+    response.headers.contains(Header("WWW-Authenticate", "www-authenticate-value")) should be(true)
   }
 
   test("Can strip certain headers from response") {
-    val response = get("/route/test/set-rack-cache-header")
+    val response = get("/route/test/set-forbidden-headers")
     response.headers.contains(Header("X-Rack-Cache", "test")) should be(false)
   }
 

--- a/router-test-harness/src/main/scala/uk/gov/gds/router/controller/TestHarnessController.scala
+++ b/router-test-harness/src/main/scala/uk/gov/gds/router/controller/TestHarnessController.scala
@@ -70,11 +70,19 @@ class TestHarnessController extends ScalatraFilter {
     output(dumpCookies)
   }
 
-  get("/test/set-header") {
-    response.addHeader("X-Test", "test")
+  get("/test/set-allowed-headers") {
+    response.addHeader("Cache-Control", "cache-control-value")
+    response.addHeader("Content-Type", "content-type-value")
+    response.addHeader("ETag", "etag-value")
+    response.addHeader("Expires", "expires-value")
+    response.addHeader("Last-Modified", "last-modified-value")
+    response.addHeader("Location", "location-value")
+    response.addHeader("Set-Cookie", "set-cookie-value")
+    response.addHeader("Vary", "vary-value")
+    response.addHeader("WWW-Authenticate", "www-authenticate-value")
   }
 
-  get("/test/set-rack-cache-header") {
+  get("/test/set-forbidden-headers") {
     response.addHeader("X-Rack-Cache", "test")
   }
 

--- a/router/src/main/scala/uk/gov/gds/router/controller/RouteController.scala
+++ b/router/src/main/scala/uk/gov/gds/router/controller/RouteController.scala
@@ -27,8 +27,17 @@ class RouteController() extends ControllerBase {
     HTTP.CONTENT_LEN,
     HTTP.TARGET_HOST)
 
-  private val responseHeadersToFilter = List(
-    "X-Rack-Cache")
+  private val responseHeaderWhitelist = List(
+    "Cache-Control",
+    "Content-Type",
+    "ETag",
+    "Expires",
+    "Last-Modified",
+    "Location",
+    "Set-Cookie",
+    "Vary",
+    "WWW-Authenticate"
+  )
 
   get("/route/*") {
     Routes.load(requestInfo.pathParameter) match {
@@ -86,7 +95,7 @@ class RouteController() extends ControllerBase {
       clientResponse.setStatus(statusCode)
 
       targetResponse.getAllHeaders
-        .filter(h => !responseHeadersToFilter.contains(h.getName))
+        .filter(h => responseHeaderWhitelist.contains(h.getName))
         .foreach(h => clientResponse.setHeader(h.getName, h.getValue))
 
       logger.info("Proxy response " + request.getMethod + " " + request.getURI + " => " + statusCode)


### PR DESCRIPTION
As discussed with @craigw and @jystewart, this functionality was previously in the slimmer gem, but is more appropriate as part of the router.
