### PR TITLE
Provide a default for the router URL

### DIFF
--- a/client/lib/router.rb
+++ b/client/lib/router.rb
@@ -5,7 +5,7 @@ class Router
 
   class ServerError < StandardError; end
 
-  def initialize(router_endpoint_url, logger=nil)
+  def initialize(router_endpoint_url="http://router.cluster:8080", logger=nil)
     @http_client = Router::HttpClient.new(router_endpoint_url, logger)
   end
 


### PR DESCRIPTION
I'm not 100% sure about the URL, specifically the port number.

I copied it from (possibly out of date) code here: https://github.com/alphagov/calendars/blob/master/lib/tasks/router.rake#L8

I considered adding it to/using Plek, but given that it's "router.cluster" in every environment, it looks like the approach is to use DNS rather than Plek for this.
