### PR TITLE
Don't swallow unexpected HTTP responses

### DIFF
--- a/client/lib/router.rb
+++ b/client/lib/router.rb
@@ -63,6 +63,8 @@ class Router
       JSON.parse(response.body).symbolize_keys
     when "500"
       raise ServerError.new
+    else
+      raise "Unexpected HTTP response: #{response.code}: #{response.message}"
     end
   end
 


### PR DESCRIPTION
Case in point: I had a typo in the URL for the router. This meant
that requests going to the router returned a 405 status, which,
were not matched in the case statement and therefore returned a nil.

Debugging then meant editing the code for the client.

You could argue that it should raise a typed error.
