### PR TITLE
Add mainstream class to body element

### DIFF
--- a/router/router/src/main/resources/error.html
+++ b/router/router/src/main/resources/error.html
@@ -29,7 +29,7 @@
   })();
   </script> 
 </head>
-<body class="citizen error">
+<body class="citizen mainstream error">
 
   <a href="#content" class="visuallyhidden">Skip to main content</a>
 


### PR DESCRIPTION
This is in preparation for replacing the citizen class.

We're going to get everything out with both classes, then switch over to using the mainstram class for everything.

Rationale: the citizen class is badly named, and going to cause confusion.
